### PR TITLE
Fix a bug in VGR calculation

### DIFF
--- a/R/calc_vgr.R
+++ b/R/calc_vgr.R
@@ -20,6 +20,6 @@ calc_vgr <- function(INR_meas) {
 
 	INR_meas[ , list(INR = mean(INR)), by = tt] %>% # this removes the tt == 0
 	with({
-		mean( diff(INR)^2 / diff(tt / 7) )
+		sqrt( mean( diff(INR)^2 / diff(tt / 7) ) )
 	})
 }

--- a/R/calc_vgr.R
+++ b/R/calc_vgr.R
@@ -20,6 +20,6 @@ calc_vgr <- function(INR_meas) {
 
 	INR_meas[ , list(INR = mean(INR)), by = tt] %>% # this removes the tt == 0
 	with({
-		sqrt( mean( diff(INR)^2 / diff(tt / 7) ) )
+		sqrt( mean( diff(INR)^2 / diff(tt) ) )
 	})
 }


### PR DESCRIPTION
I forgot a sqrt(), causing the exponent to persist.